### PR TITLE
fix(groupEP): Do not get primary mails if group is empty

### DIFF
--- a/mail_alias_creator/entry_processors/group.py
+++ b/mail_alias_creator/entry_processors/group.py
@@ -32,12 +32,13 @@ class GroupEP(EntryProcessor):
         users = LDAP.get_users_in_group(self.group)
         if users == []:
             logger.warn("Group {} has no members.".format(self.group))
-        mails = LDAP.get_user_primary_mails(users)
-        for i, mail in enumerate(mails):
-            if mail is None:
-                logger.error("User {} does not exist or has no primary mail.".format(users[i]))
-                if CONFIG["main"].getboolean("strict"):
-                    exit(1)
-            else:
-                self.add_sender(users[i])
-                self.add_recipient(mail)
+        else:
+            mails = LDAP.get_user_primary_mails(users)
+            for i, mail in enumerate(mails):
+                if mail is None:
+                    logger.error("User {} does not exist or has no primary mail.".format(users[i]))
+                    if CONFIG["main"].getboolean("strict"):
+                        exit(1)
+                else:
+                    self.add_sender(users[i])
+                    self.add_recipient(mail)


### PR DESCRIPTION
Depending on the user filter getting the primary mails of an empty group might result in all users being returned from the ldap server

However, this does not result in wrong aliases due to additional checks, but a lot of unnecessary traffic and log output (in debug mode).